### PR TITLE
Add null check for mProvider

### DIFF
--- a/common/device/android/net/NetworkFactoryImpl.java
+++ b/common/device/android/net/NetworkFactoryImpl.java
@@ -315,9 +315,8 @@ class NetworkFactoryImpl extends NetworkFactoryLegacyImpl {
     }
 
     @Override public String toString() {
-        return "providerId="
-                + mProvider.getProviderId() + ", ScoreFilter="
-                + mScore + ", Filter=" + mCapabilityFilter + ", requests="
-                + mNetworkRequests.size();
+        return "providerId=" + (mProvider != null ? mProvider.getProviderId() : "null")
+                + ", ScoreFilter=" + mScore + ", Filter=" + mCapabilityFilter
+                + ", requests=" + mNetworkRequests.size();
     }
 }

--- a/common/device/android/net/NetworkFactoryLegacyImpl.java
+++ b/common/device/android/net/NetworkFactoryLegacyImpl.java
@@ -390,9 +390,8 @@ class NetworkFactoryLegacyImpl extends Handler
     }
 
     @Override public String toString() {
-        return "providerId="
-                + mProvider.getProviderId() + ", ScoreFilter="
-                + mScore + ", Filter=" + mCapabilityFilter + ", requests="
-                + mNetworkRequests.size();
+        return "providerId=" + (mProvider != null ? mProvider.getProviderId() : "null")
+                + ", ScoreFilter=" + mScore + ", Filter=" + mCapabilityFilter
+                + ", requests=" + mNetworkRequests.size();
     }
 }


### PR DESCRIPTION
mProvider is null before register is called.
But toString call mProvider.getProviderId() without null check
and caused NullPointerException.
This commit add null check and fix this issue.

Bug: 228796405
Test: m
Change-Id: Ic8e23b21d11705219f1a8fddd544941fbddb183e